### PR TITLE
Remove Redundant list() Conversion in display_name_info Function

### DIFF
--- a/3-functional-programming/15_so_random.py
+++ b/3-functional-programming/15_so_random.py
@@ -38,7 +38,7 @@ def display_name_info():
   for name in random_names:
     print(name)
   print()
-  print('Filtered names with \'Fire\':', list(filtered_names))
+  print('Filtered names with \'Fire\':', filtered_names)
   print('Concatenated names:', reduced_names) 
 
 display_name_info()


### PR DESCRIPTION
This PR removes the unnecessary use of list() when printing filtered_names in the display_name_info function. Since filtered_names is already a list, the additional conversion is redundant. This change helps improve code clarity without affecting functionality