### PR TITLE
Update 04_fruit_cart.py to fix the extra commented check

### DIFF
--- a/1-data-structures/04_fruit_cart.py
+++ b/1-data-structures/04_fruit_cart.py
@@ -4,14 +4,14 @@
 my_fruits = {'apple', 'banana', 'kiwi'}
 friend_fruits = {'banana', 'orange', 'grape'}
 
-# Uncomment to check if a fruit is <in> both list
-# print('apple' in fruits)  # Output: True
-# set3 = {'apple', 'orange'}
-# print(set3.issubset(fruits))  # Output: True
-
 union_result = my_fruits | friend_fruits
 intersection_result = my_fruits & friend_fruits
 difference_result = my_fruits - friend_fruits
+
+# Uncomment to check if a fruit is <in> both list
+# print('apple' in union_result)  # Output: True
+# set3 = {'apple', 'orange'}
+# print(set3.issubset(union_result))  # Output: True
 
 print('Union:', union_result)
 print('Intersection:', intersection_result)


### PR DESCRIPTION
The file would attempt to pull the "fruits" variable, which is meant to be both fruits. The code fixes this by pushing the code forward, and using the union_fruits variable to follow the comments instruction. If this was intentionally broken to extend the student, please ignore this PR.