### PR TITLE
Fix incorrect test assertion for latte price

### DIFF
--- a/4-testing/20-caffeinated/test_coffee_menu.py
+++ b/4-testing/20-caffeinated/test_coffee_menu.py
@@ -10,7 +10,7 @@ class TestCoffeeMenu(unittest.TestCase):
     self.menu = CoffeeMenu()
 
   def test_get_price_existing_item(self):
-    self.assertEqual(self.menu.get_price('latte'), 3.00)
+    self.assertEqual(self.menu.get_price('latte'), 2.75)
 
   def test_get_price_non_existing_item(self):
     self.assertIsNone(self.menu.get_price('mocha'))


### PR DESCRIPTION
The current test for the latte price in test_get_price_existing_item incorrectly expects the price to be 3.00. The actual price in coffee_menu.py is 2.75.