### PR TITLE
add: print dictionary, keys and values

### DIFF
--- a/1-data-structures/03_met_museum.py
+++ b/1-data-structures/03_met_museum.py
@@ -10,3 +10,7 @@ pyxis = {
   'medium': ['terracotta', 'white-ground'],
   'dimensions': {'height': '4.75in', 'height w/cover': '6.75in'}
 }
+
+print('Printing the dictionary: ', pyxis)
+print('\nPrinting the keys: ', pyxis.keys())
+print('\nPrinting the values: ', pyxis.values())


### PR DESCRIPTION
The instructions for Exercise 03 from the Met Museum say: "Lastly, print the dictionary. What do you see? What if we just want to print the keys or the values?" However, this functionality hadn’t been implemented yet, so I added it. Now, the code prints all three requests: the entire dictionary, just the keys, and just the values.