### PR TITLE
Fix Duration Calculation in minutes_to_seconds Function

### DIFF
--- a/3-functional-programming/13_grammys.py
+++ b/3-functional-programming/13_grammys.py
@@ -11,7 +11,7 @@ def longer_than_five_minutes(song):
 def minutes_to_seconds(song):
   duration = song[1]
   minutes = int(duration)
-  seconds = (duration - minutes) * 100
+  seconds = (duration - minutes) * 60
 
   return minutes * 60 + round(seconds)
 


### PR DESCRIPTION
Updated the seconds calculation to multiply the decimal part of the duration by 60 instead of 100. This change ensures that the conversion from minutes to seconds is accurate.