### PR TITLE
Updated seconds correct number

### DIFF
--- a/3-functional-programming/13_grammys.py
+++ b/3-functional-programming/13_grammys.py
@@ -11,7 +11,7 @@ def longer_than_five_minutes(song):
 def minutes_to_seconds(song):
   duration = song[1]
   minutes = int(duration)
-  seconds = (duration - minutes) * 100
+  seconds = (duration - minutes) * 60
 
   return minutes * 60 + round(seconds)
 


### PR DESCRIPTION
To convert the duration into seconds, we multiply by 60 not 100. This is because there are 60 seconds in a minute, not 100.