### PR TITLE
fix: remove unnecessary list() function

### DIFF
--- a/3-functional-programming/14_mental_math.py
+++ b/3-functional-programming/14_mental_math.py
@@ -8,5 +8,5 @@ numbers = [57, 10, 82, 36, 89, 46, 13, 23, 92, 48]
 even_numbers = [num for num in numbers if num % 2 == 0]
 
 # Display the original range and the list of even numbers
-print('Original Range:', list(numbers))
+print('Original Range:', numbers)
 print('Even Numbers:', even_numbers)


### PR DESCRIPTION
I noticed an unnecessary/redundant function in a print statement. I think that we can remove it, because 'numbers' is already defined as a list.